### PR TITLE
Split run.sh into test_functions.sh and a run.sh that sources and runs it.

### DIFF
--- a/tests/install-uninstall-pas-tile/Dockerfile
+++ b/tests/install-uninstall-pas-tile/Dockerfile
@@ -19,7 +19,7 @@ RUN mrlog dependency --type binary --name marman --version $(marman version | cu
     mrlog dependency --type binary --name tileinspect --version $(tileinspect version | cut -d" " -f3) >> ${DEPENDENCIES_FILE}
 
 # Copy files for this test
-COPY [ "needs.json", "run.sh", "/test/" ]
+COPY [ "needs.json", "run.sh", "test_functions.sh", "/test/" ]
 RUN chmod a+x /test/run.sh
 WORKDIR /test
 

--- a/tests/install-uninstall-pas-tile/run.bats
+++ b/tests/install-uninstall-pas-tile/run.bats
@@ -58,7 +58,7 @@ teardown() {
     [ "$(mock_get_call_num "${mock_tileinspect}")" = "0" ]
     [ "$(mock_get_call_num "${mock_install_tile_sh}")" = "0" ]
     [ "$(mock_get_call_num "${mock_uninstall_tile_sh}")" = "0" ]
-    output_equals "needs check failed"
+    output_equals "Needs check indicated that the test is not ready to execute"
 }
 
 @test "test exits before installing if check-config fails" {
@@ -71,7 +71,7 @@ teardown() {
     [ "$(mock_get_call_num "${mock_tileinspect}")" = "1" ]
     [ "$(mock_get_call_num "${mock_install_tile_sh}")" = "0" ]
     [ "$(mock_get_call_num "${mock_uninstall_tile_sh}")" = "0" ]
-    output_equals "config file check failed"
+    output_equals "The supplied config file will not work for the tile"
 }
 
 @test "returns error code when install tile fails" {
@@ -80,7 +80,7 @@ teardown() {
     run ${BATS_TEST_DIRNAME}/run.sh
 
     status_equals 1
-    output_equals "install-tile failed"
+    output_equals "Failed to stage, configure, or deploy the tile"
 }
 
 @test "returns error code when uninstall tile fails" {
@@ -89,5 +89,5 @@ teardown() {
     run ${BATS_TEST_DIRNAME}/run.sh
 
     status_equals 1
-    output_equals "uninstall-tile failed"
+    output_equals "Failed to uninstall the tile"
 }

--- a/tests/install-uninstall-pas-tile/run.sh
+++ b/tests/install-uninstall-pas-tile/run.sh
@@ -1,43 +1,8 @@
 #!/usr/bin/env bash
 
-mrlog section-start --name="needs check"
-needs check
-result=$?
-mrlog section-end --name="needs check" --result=${result}
-if [[ $result -ne 0 ]] ; then
-    echo "needs check failed" >&2
-    exit 1
-fi
-
-mrlog section-start --name="config file check"
-tileinspect check-config --tile "/input/tile/${TILE_NAME}" --config "/input/tile-config/${TILE_CONFIG}"
-result=$?
-mrlog section-end --name="config file check" --result=${result}
-if [[ $result -ne 0 ]] ; then
-    echo "config file check failed" >&2
-    exit 1
-fi
-
-mrlog section-start --name="dependencies"
-if [ -f /root/dependencies.log ] ; then
-    cat /root/dependencies.log
-fi
-mrlog section-end --name="dependencies" --result=0
-
-mrlog section-start --name="tile install"
-install-tile.sh "/input/tile/${TILE_NAME}" "/input/tile-config/${TILE_CONFIG}" "${USE_FULL_DEPLOY:-false}"
-result=$?
-mrlog section-end --name="tile install" --result=$result
-if [[ $result -ne 0 ]] ; then
-    echo "install-tile failed" >&2
-    exit 1
-fi
-
-mrlog section-start --name="tile uninstall"
-uninstall-tile.sh "/input/tile/${TILE_NAME}" "${USE_FULL_DEPLOY:-false}"
-result=$?
-mrlog section-end --name="tile uninstall" --result=$result
-if [[ $result -ne 0 ]] ; then
-    echo "uninstall-tile failed" >&2
-    exit 1
-fi
+source ./test_functions.sh
+if ! needs_check            ; then exit 1 ; fi
+if ! config_file_check      ; then exit 1 ; fi
+if ! log_dependencies       ; then exit 1 ; fi
+if ! install_tile           ; then exit 1 ; fi
+if ! uninstall_tile         ; then exit 1 ; fi

--- a/tests/install-uninstall-pas-tile/test_functions.sh
+++ b/tests/install-uninstall-pas-tile/test_functions.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+function needs_check {
+    mrlog section-start --name="checking test needs"
+
+    needs check
+    result=$?
+    mrlog section-end --name="checking test needs" --result=${result}
+
+    if [[ $result -ne 0 ]] ; then
+        echo "Needs check indicated that the test is not ready to execute" >&2
+    fi
+    return $result
+}
+
+function config_file_check {
+    mrlog section-start --name="config file check"
+    tileinspect check-config --tile "/input/tile/${TILE_NAME}" --config "/input/tile-config/${TILE_CONFIG}"
+    result=$?
+    mrlog section-end --name="config file check" --result=${result}
+
+    if [[ $result -ne 0 ]] ; then
+        echo "The supplied config file will not work for the tile" >&2
+    fi
+    return $result
+}
+
+function log_dependencies {
+    mrlog section-start --name="dependencies"
+    if [ -f /root/dependencies.log ] ; then
+        cat /root/dependencies.log
+    fi
+    mrlog section-end --name="dependencies" --result=0
+}
+
+function install_tile {
+    mrlog section-start --name="tile install"
+    install-tile.sh "/input/tile/${TILE_NAME}" "/input/tile-config/${TILE_CONFIG}" "${USE_FULL_DEPLOY:-false}"
+    result=$?
+    mrlog section-end --name="tile install" --result=$result
+    if [[ $result -ne 0 ]] ; then
+        echo "Failed to stage, configure, or deploy the tile" >&2
+    fi
+    return $result
+}
+
+function uninstall_tile {
+    mrlog section-start --name="tile uninstall"
+    uninstall-tile.sh "/input/tile/${TILE_NAME}" "${USE_FULL_DEPLOY:-false}"
+    result=$?
+    mrlog section-end --name="tile uninstall" --result=$result
+    if [[ $result -ne 0 ]] ; then
+        echo "Failed to uninstall the tile" >&2
+    fi
+    return $result
+}


### PR DESCRIPTION
This would allow for users to `source test_functions.sh` when doing `make shell`.

Preserving `run.sh` as the runnable script has these advantages:
* Keeps this line in the Dockerfile, which is very clear to understand: `CMD ["/bin/bash", "-c", "/test/run.sh"]`
* Allows for users that inherit from this test to overwrite run.sh with their own execution logic.